### PR TITLE
Feat: listagem de produtos e filtro por categoria_id

### DIFF
--- a/src/controllers/productController.js
+++ b/src/controllers/productController.js
@@ -87,5 +87,41 @@ const updateProduct = async (req, res) => {
     }
 };
 
+const getProducts = async (req, res) => {
+  let { categoria_id } = req.query;
 
-module.exports = { registerProduct, updateProduct };
+  try {
+    if (!categoria_id) {
+      const products = await knex("produtos");
+
+      return res.status(200).json(products);
+    }
+
+    if (typeof categoria_id === "string") categoria_id = Array(categoria_id);
+
+    const categoryFound = await knex("categorias").whereIn("id", categoria_id);
+
+    if (!categoryFound.length) {
+      return res.status(404).json({ mensagem: "Categoria inválida!" });
+    }
+
+    const filteredProducts = await knex("produtos").whereIn(
+      "categoria_id",
+      categoria_id
+    );
+
+    if (!filteredProducts.length) {
+      return res.status(400).json({
+        mensagem:
+          "Não foi encontrado nenhum produto cadastrado com essa categoria!",
+      });
+    }
+
+    return res.status(200).json(filteredProducts);
+  } catch (error) {
+    return res.status(500).json({ mensagem: "Erro interno do servidor" });
+  }
+};
+
+
+module.exports = { registerProduct, updateProduct, getProducts };

--- a/src/routes.js
+++ b/src/routes.js
@@ -17,7 +17,8 @@ const authenticatedUser = require("./middlewares/authentication");
 
 const {
   registerProduct,
-  updateProduct
+  updateProduct,
+  getProducts
 } = require("./controllers/productController");
 const productSchema = require("./validations/productSchema");
 
@@ -33,6 +34,7 @@ route.use(authenticatedUser);
 route.get("/usuario", detailUser);
 route.put("/usuario", validateRequest(userSchema), updateUser);
 
+route.get("/produto", getProducts);
 route.post("/produto", validateRequest(productSchema), registerProduct);
 route.put("/produto/:id", validateRequest(productSchema), updateProduct);
 


### PR DESCRIPTION
Criada a rota de listagem de produtos e filtro por categorias. Sendo que, os id's das categorias são recebidos opcionalmente como query param, e caso não sejam enviados ocorre a listagem de todos produtos cadastrados para o usuário.

Importante lembrar que, existem comportamentos diferentes caso o usuário envie id's de categorias, sendo eles:

1. Caso o usuário envie vários id's de categorias e apenas um deles seja válido e exista produto vinculado à essa categoria, é filtrado apenas o produto válido;
2. Caso usuário envie vários id's inválidos (os quais não existam cadastrados na tabela categorias), é retornada mensagem de erro informando: "Categoria inválida!";
3. Caso o usuário envie vários id's válidos (os quais existam cadastrados na tabela categorias), porém não exista nenhum produto cadastrado vinculado a essas categorias, é retornada mensagem de erro informando: "Não foi encontrado nenhum produto cadastrado com essa categoria!".